### PR TITLE
Update PrefixDBPedia.txt

### DIFF
--- a/PrefixDBPedia.txt
+++ b/PrefixDBPedia.txt
@@ -131,7 +131,7 @@ gml	http://www.opengis.net/gml
 go	http://purl.org/obo/owl/GO#
 hlisting	http://www.openlinksw.com/schemas/hlisting/
 hoovers	http://wwww.hoovers.com/
-hrev	http:/www.purl.org/stuff/hrev#
+hrev	http://www.purl.org/stuff/hrev#
 ical	http://www.w3.org/2002/12/cal/ical#
 ir	http://web-semantics.org/ns/image-regions
 itunes	http://www.itunes.com/DTDs/Podcast-1.0.dtd
@@ -182,7 +182,7 @@ rdfa	http://www.w3.org/ns/rdfa#
 rdfdf	http://www.openlinksw.com/virtrdf-data-formats#
 rdfs	http://www.w3.org/2000/01/rdf-schema#
 rev	http://purl.org/stuff/rev#
-review	http:/www.purl.org/stuff/rev#
+review	http://www.purl.org/stuff/rev#
 rss	http://purl.org/rss/1.0/
 sc	http://purl.org/science/owl/sciencecommons/
 schema	http://schema.org/


### PR DESCRIPTION
common problem http:/www.purl.org/stuff/hrev is missing a slash all over the internet